### PR TITLE
fix IndexOutOfBoundsException: Index: 0, Size: 0 while editing

### DIFF
--- a/violet-framework/src/main/java/com/horstmann/violet/workspace/editorpart/behavior/UndoRedoOnTransitionPointChangeBehavior.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/workspace/editorpart/behavior/UndoRedoOnTransitionPointChangeBehavior.java
@@ -66,10 +66,12 @@ public class UndoRedoOnTransitionPointChangeBehavior extends AbstractEditorPartB
 	private void captureDraggedPoints(final IEdge edge, CompoundEdit capturedEdit) {
 		boolean isSameQuantity = (this.transitionPointsBeforeChanges.size() == this.transitionPointsAfterChanges.size());
 		boolean isSameLocation = true;
-		for (int i = 0; i < this.transitionPointsBeforeChanges.size(); i++) {
-            Point2D beforeDragPoint = this.transitionPointsBeforeChanges.get(i);
-            Point2D afterDragPoint = this.transitionPointsAfterChanges.get(i);
-            isSameLocation = isSameLocation && beforeDragPoint.equals(afterDragPoint);
+		if (! this.transitionPointsAfterChanges.isEmpty()) { 
+			for (int i = 0; i < this.transitionPointsBeforeChanges.size(); i++) {
+	            Point2D beforeDragPoint = this.transitionPointsBeforeChanges.get(i);
+	            Point2D afterDragPoint = this.transitionPointsAfterChanges.get(i);
+	            isSameLocation = isSameLocation && beforeDragPoint.equals(afterDragPoint);
+			}
 		}
 		boolean isDragged = isSameQuantity && !isSameLocation;
 		if (!isDragged) {

--- a/violet-framework/src/main/java/com/horstmann/violet/workspace/editorpart/behavior/UndoRedoOnTransitionPointChangeBehavior.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/workspace/editorpart/behavior/UndoRedoOnTransitionPointChangeBehavior.java
@@ -62,16 +62,28 @@ public class UndoRedoOnTransitionPointChangeBehavior extends AbstractEditorPartB
 		captureDraggedPoints(edge, capturedEdit);
 		this.compoundBehavior.stopHistoryCapture();
 	}
-
+/* before, after after
+ * 		else {
+			System.out.println("before changes skip occured.");
+		}*/
+	private static final String LOG_AFTER_EVENT = "after changes skip occured (before=%d > after=%d).";
+	private static final String LOG_BEFORE_EVENT = "before changes skip occured (after=%d > before=%d).";
 	private void captureDraggedPoints(final IEdge edge, CompoundEdit capturedEdit) {
-		boolean isSameQuantity = (this.transitionPointsBeforeChanges.size() == this.transitionPointsAfterChanges.size());
+		int beforeSize = this.transitionPointsBeforeChanges.size();
+		int afterSize = this.transitionPointsAfterChanges.size();
+		boolean isSameQuantity = (beforeSize == afterSize);
 		boolean isSameLocation = true;
-		if (! this.transitionPointsAfterChanges.isEmpty()) { 
-			for (int i = 0; i < this.transitionPointsBeforeChanges.size(); i++) {
-	            Point2D beforeDragPoint = this.transitionPointsBeforeChanges.get(i);
-	            Point2D afterDragPoint = this.transitionPointsAfterChanges.get(i);
-	            isSameLocation = isSameLocation && beforeDragPoint.equals(afterDragPoint);
-			}
+		/* 
+		 * debugging: previously only beforeSize was tested, so log when beforeSize is greater than afterSize,
+		 * which would mean that indexing into transitionPointsAfterChanges would become invalid.
+		 */
+		if (beforeSize > afterSize) {
+			System.out.println(String.format(LOG_AFTER_EVENT, beforeSize, afterSize));
+		}
+		for (int i = 0; ((i < beforeSize) && (i < afterSize)); i++) {
+            Point2D beforeDragPoint = this.transitionPointsBeforeChanges.get(i);
+            Point2D afterDragPoint = this.transitionPointsAfterChanges.get(i);
+            isSameLocation = isSameLocation && beforeDragPoint.equals(afterDragPoint);
 		}
 		boolean isDragged = isSameQuantity && !isSameLocation;
 		if (!isDragged) {
@@ -82,7 +94,16 @@ public class UndoRedoOnTransitionPointChangeBehavior extends AbstractEditorPartB
 		UndoableEdit edit = new AbstractUndoableEdit() {
 			@Override
 			public void undo() throws CannotUndoException {
-				for (int i = 0; i < transitionPointsAfterChangesCopy.size(); i++) {
+				int beforeCopySize = transitionPointsBeforeChangesCopy.size();
+				int afterCopySize = transitionPointsAfterChangesCopy.size();
+				/* 
+				 * debugging: previously only afterCopySize was tested, so log when afterCopySize is greater than beforeCopySize,
+				 * which would mean that indexing into transitionPointsBeforeChangesCopy would become invalid.
+				 */
+				if (afterCopySize > beforeCopySize) {
+					System.err.println(String.format(LOG_BEFORE_EVENT, afterCopySize, beforeCopySize));
+				}
+				for (int i = 0; ((i < beforeCopySize) && (i < afterCopySize)); i++) {
 					Point2D beforeDragPoint = transitionPointsBeforeChangesCopy.get(i);
 					Point2D afterDragPoint = transitionPointsAfterChangesCopy.get(i);
 					if (afterDragPoint.getX() != beforeDragPoint.getX() || afterDragPoint.getY() != beforeDragPoint.getY()) {
@@ -94,7 +115,16 @@ public class UndoRedoOnTransitionPointChangeBehavior extends AbstractEditorPartB
 
 			@Override
 			public void redo() throws CannotRedoException {
-				for (int i = 0; i < transitionPointsAfterChangesCopy.size(); i++) {
+				int beforeCopySize = transitionPointsBeforeChangesCopy.size();
+				int afterCopySize = transitionPointsAfterChangesCopy.size();
+				/* 
+				 * debugging: previously only afterCopySize was tested, so log when afterCopySize is greater than beforeCopySize,
+				 * which would mean that indexing into transitionPointsBeforeChangesCopy would become invalid.
+				 */
+				if (afterCopySize > beforeCopySize) {
+					System.err.println(String.format(LOG_BEFORE_EVENT, afterCopySize, beforeCopySize));
+				}
+				for (int i = 0; ((i < beforeCopySize) && (i < afterCopySize)); i++) {
 					Point2D beforeDragPoint = transitionPointsBeforeChangesCopy.get(i);
 					Point2D afterDragPoint = transitionPointsAfterChangesCopy.get(i);
 					if (afterDragPoint.getX() != beforeDragPoint.getX() || afterDragPoint.getY() != beforeDragPoint.getY()) {


### PR DESCRIPTION
Crash while editing.  I think I was adding or editing the position of an inherits or implements line.  I attempted a fix, but I'm not sure how to reproduce the problem to test.
```
Exception in thread "AWT-EventQueue-1" java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:571)
	at java.util.ArrayList.get(ArrayList.java:349)
	at com.horstmann.violet.workspace.editorpart. behavior.UndoRedoOnTransitionPointChangeBehavior.captureDraggedPoints(UndoRedoOnTransitionPointChangeBehavior.java:71)
	at com.horstmann.violet.workspace.editorpart.behavior.UndoRedoOnTransitionPointChangeBehavior.afterChangingTransitionPointsOnEdge(UndoRedoOnTransitionPointChangeBehavior.java:62)
	at com.horstmann.violet.workspace.editorpart.behavior.UndoRedoCompoundBehavior.afterChangingTransitionPointsOnEdge(UndoRedoCompoundBehavior.java:150)
	at com.horstmann.violet.workspace.editorpart.EditorPartBehaviorManager.fireAfterChangingTransitionPointsOnEdge(EditorPartBehaviorManager.java:194)
	at com.horstmann.violet.workspace.editorpart.behavior.DragTransitionPointBehavior.stopUndoRedoCapture(DragTransitionPointBehavior.java:190)
	at com.horstmann.violet.workspace.editorpart.behavior.DragTransitionPointBehavior.onMouseReleased(DragTransitionPointBehavior.java:103)
	at com.horstmann.violet.workspace.editorpart.EditorPartBehaviorManager.fireOnMouseReleased(EditorPartBehaviorManager.java:61)
	at com.horstmann.violet.workspace.editorpart.EditorPart$1.mouseReleased(EditorPart.java:72)
	at java.awt.Component.processMouseEvent(Component.java:6288)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3267)
```