### PR TITLE
Migrate project to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,16 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.11.0</version>
+					<version>3.13.0</version>
 					<configuration>
-						<release>17</release>
+						<release>21</release>
 					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.2.3</version>
+					<version>3.3.0</version>
 					<configuration>
-					  <skipTests>true</skipTests>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/violet-framework/src/main/java/com/horstmann/violet/framework/dialog/DialogFactory.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/framework/dialog/DialogFactory.java
@@ -250,7 +250,7 @@ public class DialogFactory
             {
                     optionPane,
                     title,
-                    new Boolean(isModal)
+                    Boolean.valueOf(isModal)
             });
         }
     }

--- a/violet-framework/src/main/java/com/horstmann/violet/framework/file/persistence/StandardJavaFilePersistenceService.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/framework/file/persistence/StandardJavaFilePersistenceService.java
@@ -100,8 +100,8 @@ public class StandardJavaFilePersistenceService implements IFilePersistenceServi
                 Point2D p = (Point2D) oldInstance;
                 out.writeStatement(new Statement(oldInstance, "setLocation", new Object[]
                 {
-                        new Double(p.getX()),
-                        new Double(p.getY())
+                        Double.valueOf(p.getX()),
+                        Double.valueOf(p.getY())
                 }));
             }
         });
@@ -113,10 +113,10 @@ public class StandardJavaFilePersistenceService implements IFilePersistenceServi
                 Line2D l = (Line2D) oldInstance;
                 out.writeStatement(new Statement(oldInstance, "setLine", new Object[]
                 {
-                        new Double(l.getX1()),
-                        new Double(l.getY1()),
-                        new Double(l.getX2()),
-                        new Double(l.getY2())
+                        Double.valueOf(l.getX1()),
+                        Double.valueOf(l.getY1()),
+                        Double.valueOf(l.getX2()),
+                        Double.valueOf(l.getY2())
                 }));
             }
         });
@@ -128,10 +128,10 @@ public class StandardJavaFilePersistenceService implements IFilePersistenceServi
                 Rectangle2D r = (Rectangle2D) oldInstance;
                 out.writeStatement(new Statement(oldInstance, "setRect", new Object[]
                 {
-                        new Double(r.getX()),
-                        new Double(r.getY()),
-                        new Double(r.getWidth()),
-                        new Double(r.getHeight())
+                        Double.valueOf(r.getX()),
+                        Double.valueOf(r.getY()),
+                        Double.valueOf(r.getWidth()),
+                        Double.valueOf(r.getHeight())
                 }));
             }
         });

--- a/violet-framework/src/main/java/com/horstmann/violet/product/diagram/common/DiagramLink.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/product/diagram/common/DiagramLink.java
@@ -46,7 +46,7 @@ public class DiagramLink
     /**
      * Flag to indicate if file needs to be opened
      */
-    private Boolean openFlag = new Boolean(false);
+    private Boolean openFlag = Boolean.valueOf(false);
 
     public DiagramLink()
     {
@@ -96,6 +96,7 @@ public class DiagramLink
     /**
      * @deprecated kept for compatibility
      */
+    @Deprecated
     public URL getURL()
     {
         if (this.file == null) {
@@ -116,6 +117,7 @@ public class DiagramLink
     /**
      * @deprecated kept for compatibility
      */
+    @Deprecated
     public void setURL(URL url)
     {
         try {

--- a/violetproduct-swing/src/main/java/com/horstmann/violet/UMLEditorApplet.java
+++ b/violetproduct-swing/src/main/java/com/horstmann/violet/UMLEditorApplet.java
@@ -25,7 +25,7 @@ import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.JApplet;
+import javax.swing.JApplet; // deprecated
 import javax.swing.JFrame;
 
 import com.horstmann.violet.application.gui.MainFrame;
@@ -50,6 +50,7 @@ import com.horstmann.violet.framework.userpreferences.IUserPreferencesDao;
 /**
  * A program for editing UML diagrams.
  */
+@SuppressWarnings("deprecation")
 public class UMLEditorApplet extends JApplet
 {
 

--- a/violetproduct-swing/src/main/java/com/horstmann/violet/application/help/AboutDialog.java
+++ b/violetproduct-swing/src/main/java/com/horstmann/violet/application/help/AboutDialog.java
@@ -118,6 +118,7 @@ public class AboutDialog extends JDialog
         setLocation(x - getWidth() / 2, y - getHeight() / 2);
     }
 
+    @SuppressWarnings("removal")
     private JPanel getSystemInfoPanel()
     {
         if (this.systemInfoPanel == null)


### PR DESCRIPTION
This commit migrates the project from Java 17 to Java 21.

Key changes include:
- Updated Java version to 21 in `pom.xml`.
- Updated Maven plugins: `maven-compiler-plugin` to 3.13.0 and `maven-surefire-plugin` to 3.3.0.
- Enabled tests by removing `<skipTests>true</skipTests>` from Surefire configuration.
- Addressed critical code changes for Java 21 compatibility, including:
    - Replaced deprecated `Boolean` and `Double` constructors.
    - Added `@Deprecated` annotations where appropriate.
    - Suppressed warnings for `JApplet` deprecation and `AccessControlException` in applet context.

The project builds successfully with Java 21. No unit tests were found in the project.