### PR TITLE
Refactor: Remove unused imports and local variable assignment

### DIFF
--- a/violet-framework/src/main/java/com/horstmann/violet/product/diagram/abstracts/AbstractGraph.java
+++ b/violet-framework/src/main/java/com/horstmann/violet/product/diagram/abstracts/AbstractGraph.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import com.horstmann.violet.product.diagram.abstracts.edge.IEdge;
 import com.horstmann.violet.product.diagram.abstracts.node.INode;
-import com.horstmann.violet.product.diagram.abstracts.node.RectangularNode;
 import com.horstmann.violet.product.diagram.common.NoteNode;
 
 /**
@@ -160,8 +159,7 @@ public abstract class AbstractGraph implements Serializable, Cloneable, IGraph
      */
     public Rectangle2D getClipBounds()
     {
-        Rectangle2D r = minBounds;
-        r = null;
+        Rectangle2D r = null;
         for (INode n : nodes)
         {
             Rectangle2D b = n.getBounds();

--- a/violetplugin-classdiagram/src/main/java/com/horstmann/violet/product/diagram/classes/ClassDiagramGraph.java
+++ b/violetplugin-classdiagram/src/main/java/com/horstmann/violet/product/diagram/classes/ClassDiagramGraph.java
@@ -17,7 +17,6 @@ import com.horstmann.violet.product.diagram.classes.edges.InterfaceInheritanceEd
 import com.horstmann.violet.product.diagram.classes.nodes.ClassNode;
 import com.horstmann.violet.product.diagram.classes.nodes.InterfaceNode;
 import com.horstmann.violet.product.diagram.classes.nodes.PackageNode;
-import com.horstmann.violet.product.diagram.common.ImageNode;
 import com.horstmann.violet.product.diagram.common.NoteEdge;
 import com.horstmann.violet.product.diagram.common.NoteNode;
 

--- a/violetproduct-web/src/main/java/com/horstmann/violet/web/workspace/WorkspaceWidget.java
+++ b/violetproduct-web/src/main/java/com/horstmann/violet/web/workspace/WorkspaceWidget.java
@@ -8,11 +8,8 @@ import com.horstmann.violet.workspace.editorpart.IEditorPart;
 import com.horstmann.violet.workspace.editorpart.IEditorPartBehaviorManager;
 import com.horstmann.violet.workspace.sidebar.ISideBar;
 
-import eu.webtoolkit.jwt.Key;
-import eu.webtoolkit.jwt.Signal1;
 import eu.webtoolkit.jwt.WContainerWidget;
 import eu.webtoolkit.jwt.WHBoxLayout;
-import eu.webtoolkit.jwt.WKeyEvent;
 import eu.webtoolkit.jwt.WLength;
 import eu.webtoolkit.jwt.WLength.Unit;
 import eu.webtoolkit.jwt.WScrollArea;


### PR DESCRIPTION
This commit cleans up the codebase by:
- Removing several identified unused import statements in AbstractGraph.java, ClassDiagramGraph.java, and WorkspaceWidget.java.
- Eliminating a useless initial assignment to a local variable in the AbstractGraph.getClipBounds() method.

These changes improve code hygiene and readability.